### PR TITLE
update: replace golang receiver names

### DIFF
--- a/rabbitmq/binding.go
+++ b/rabbitmq/binding.go
@@ -6,25 +6,25 @@ import (
 )
 
 // DeclareBindings declares all bindings from a list of bindings
-func (self *Declarator) DeclareBindings(bindings []Binding) {
+func (d *Declarator) DeclareBindings(bindings []Binding) {
 	for _, binding := range bindings {
-		self.Bind(binding)
+		d.Bind(binding)
 	}
 }
 
 // Bind binds a queue or exchange to another exchange
-func (self *Declarator) Bind(binding Binding) {
+func (d *Declarator) Bind(binding Binding) {
 	if binding.DestinationType == "queue" {
-		self.bindQueue(binding)
+		d.bindQueue(binding)
 	}
 
 	if binding.DestinationType == "exchange" {
-		self.bindExchange(binding)
+		d.bindExchange(binding)
 	}
 }
 
-func (self *Declarator) bindQueue(binding Binding) {
-	err := self.conn.QueueBind(
+func (d *Declarator) bindQueue(binding Binding) {
+	err := d.conn.QueueBind(
 		binding.Destination,
 		binding.RoutingKey,
 		binding.Source,
@@ -39,8 +39,8 @@ func (self *Declarator) bindQueue(binding Binding) {
 	log.Warn("[RabbitMQ] [Binding] Queue " + binding.Destination + " binded with exchange " + binding.Source)
 }
 
-func (self *Declarator) bindExchange(binding Binding) {
-	err := self.conn.ExchangeBind(
+func (d *Declarator) bindExchange(binding Binding) {
+	err := d.conn.ExchangeBind(
 		binding.Destination,
 		binding.RoutingKey,
 		binding.Source,

--- a/rabbitmq/declarator.go
+++ b/rabbitmq/declarator.go
@@ -22,7 +22,7 @@ func NewDeclarator(conn *amqp.Channel) *Declarator {
 }
 
 // DeclareExchanges declares all exchanges ,queues and bindings from a broker definition json file
-func (self *Declarator) DeclareFromFile(filePath string) {
+func (d *Declarator) DeclareFromFile(filePath string) {
 	jsonFile, err := os.Open(filePath)
 	if err != nil {
 		log.Error("[RabbitMQ] [Declarator] Error when trying to open file " + filePath)
@@ -36,9 +36,9 @@ func (self *Declarator) DeclareFromFile(filePath string) {
 	byteValue, _ := io.ReadAll(jsonFile)
 	_ = json.Unmarshal(byteValue, &definition)
 
-	self.DeclareExchanges(definition.Exchanges)
-	self.DeclareQueues(definition.Queues)
-	self.DeclareBindings(definition.Bindings)
+	d.DeclareExchanges(definition.Exchanges)
+	d.DeclareQueues(definition.Queues)
+	d.DeclareBindings(definition.Bindings)
 
 	log.Info("[RabbitMQ] [Declarator] All exchanges, queues and bindings declared from file " + filePath + " successfully!")
 }

--- a/rabbitmq/definitions.go
+++ b/rabbitmq/definitions.go
@@ -67,29 +67,29 @@ type Binding struct {
 }
 
 // GetArguments returns the arguments of an exchange
-func (self *ExchangeArguments) GetArguments() amqp.Table {
+func (ea *ExchangeArguments) GetArguments() amqp.Table {
 	arguments := amqp.Table{}
 
-	addNonEmpty(arguments, "alternate-exchange", self.AlternateExchange, "string")
+	addNonEmpty(arguments, "alternate-exchange", ea.AlternateExchange, "string")
 
 	return arguments
 }
 
 // GetArguments returns the arguments of a queue
-func (self *QueueArguments) GetArguments() amqp.Table {
+func (qa *QueueArguments) GetArguments() amqp.Table {
 	arguments := amqp.Table{}
 
-	addNonEmpty(arguments, "x-message-ttl", self.XMessageTTL, "int32")
-	addNonEmpty(arguments, "x-expires", self.XExpires, "int32")
-	addNonEmpty(arguments, "x-overflow", self.XOverflow, "string")
-	addNonEmpty(arguments, "x-single-active-consumer", self.XSingleActiveConsumer, "bool")
-	addNonEmpty(arguments, "x-dead-letter-exchange", self.XDeadLetterExchange, "string")
-	addNonEmpty(arguments, "x-dead-letter-routing-key", self.XDeadLetterRoutingKey, "string")
-	addNonEmpty(arguments, "x-max-length", self.XMaxLength, "int32")
-	addNonEmpty(arguments, "x-max-length-bytes", self.XMaxLengthBytes, "int32")
-	addNonEmpty(arguments, "x-max-priority", self.XMaxPriority, "int32")
-	addNonEmpty(arguments, "x-queue-mode", self.XQueueMode, "string")
-	addNonEmpty(arguments, "x-queue-master-locator", self.XQueueMasterLocator, "string")
+	addNonEmpty(arguments, "x-message-ttl", qa.XMessageTTL, "int32")
+	addNonEmpty(arguments, "x-expires", qa.XExpires, "int32")
+	addNonEmpty(arguments, "x-overflow", qa.XOverflow, "string")
+	addNonEmpty(arguments, "x-single-active-consumer", qa.XSingleActiveConsumer, "bool")
+	addNonEmpty(arguments, "x-dead-letter-exchange", qa.XDeadLetterExchange, "string")
+	addNonEmpty(arguments, "x-dead-letter-routing-key", qa.XDeadLetterRoutingKey, "string")
+	addNonEmpty(arguments, "x-max-length", qa.XMaxLength, "int32")
+	addNonEmpty(arguments, "x-max-length-bytes", qa.XMaxLengthBytes, "int32")
+	addNonEmpty(arguments, "x-max-priority", qa.XMaxPriority, "int32")
+	addNonEmpty(arguments, "x-queue-mode", qa.XQueueMode, "string")
+	addNonEmpty(arguments, "x-queue-master-locator", qa.XQueueMasterLocator, "string")
 
 	return arguments
 }

--- a/rabbitmq/exchange.go
+++ b/rabbitmq/exchange.go
@@ -3,8 +3,8 @@ package rabbitmq
 import log "github.com/sirupsen/logrus"
 
 // DeclareExchange declares an exchange
-func (self *Declarator) DeclareExchange(exchange Exchange) {
-	err := self.conn.ExchangeDeclare(
+func (d *Declarator) DeclareExchange(exchange Exchange) {
+	err := d.conn.ExchangeDeclare(
 		exchange.Name,
 		exchange.Type,
 		exchange.Durable,
@@ -21,8 +21,8 @@ func (self *Declarator) DeclareExchange(exchange Exchange) {
 }
 
 // DeclareExchanges declares all exchanges from a list of exchanges
-func (self *Declarator) DeclareExchanges(exchange []Exchange) {
+func (d *Declarator) DeclareExchanges(exchange []Exchange) {
 	for _, exchange := range exchange {
-		self.DeclareExchange(exchange)
+		d.DeclareExchange(exchange)
 	}
 }

--- a/rabbitmq/queue.go
+++ b/rabbitmq/queue.go
@@ -3,8 +3,8 @@ package rabbitmq
 import log "github.com/sirupsen/logrus"
 
 // DeclareQueue declares a queue
-func (self *Declarator) DeclareQueue(queue Queue) {
-	declaredQueue, err := self.conn.QueueDeclare(
+func (d *Declarator) DeclareQueue(queue Queue) {
+	declaredQueue, err := d.conn.QueueDeclare(
 		queue.Name,
 		queue.Durable,
 		queue.AutoDelete,
@@ -21,8 +21,8 @@ func (self *Declarator) DeclareQueue(queue Queue) {
 }
 
 // DeclareQueues declares all queues from a list of queues
-func (self *Declarator) DeclareQueues(queues []Queue) {
+func (d *Declarator) DeclareQueues(queues []Queue) {
 	for _, queue := range queues {
-		self.DeclareQueue(queue)
+		d.DeclareQueue(queue)
 	}
 }


### PR DESCRIPTION
Using generic names such "this" or "self" does not follow Golang naming convention, also the language is not OOP, and those names creates linter warning.